### PR TITLE
Improve config and add toggleable hotkey guide bar

### DIFF
--- a/config_manager.py
+++ b/config_manager.py
@@ -34,7 +34,8 @@ class ConfigManager:
             with open(self.file_path, 'w') as f:
                 f.write(_DEFAULT_CONFIG)
         self.config = configparser.ConfigParser()
-        self.config.read(self.file_path)
+        self.config.read_string(_DEFAULT_CONFIG)  # seeds defaults for any missing keys
+        self.config.read(self.file_path)          # user values override
 
     def set_config_settings_value(self, key, value):
         self.config.set('settings', key, str(value))

--- a/config_manager.py
+++ b/config_manager.py
@@ -1,57 +1,51 @@
-"""
-    Reads and writes to a config file.
-"""
-
+"""Reads and writes to a config file."""
 import os
 import configparser
 
-default_config = """[keys]
-                    up = e
-                    down = n
-                    open_parent = k
-                    open_child = i
-                    quit = q
-                    open_terminal = t
-                    open_file = \\n
-                    toggle_hidden = h
-                    delete = x
-                    new_folder = f
-                    rename = r
-                    copy = c
-                    paste = p
-                    cut = d
-                    zip_unzip = z
-                    mark_item = m
-                    undo = u
-                    
-                    [settings]
-                    show_hidden = False"""
+_DEFAULT_CONFIG = """[keys]
+up = e
+down = n
+open_parent = k
+open_child = i
+quit = q
+open_terminal = t
+open_file = \\n
+toggle_hidden = h
+delete = x
+new_folder = f
+rename = r
+copy = c
+paste = p
+cut = d
+zip_unzip = z
+mark_item = m
+undo = u
+toggle_hotkeys = ?
+
+[settings]
+show_hidden = False
+show_hotkeys = True"""
 
 
 class ConfigManager:
     def __init__(self):
-        # home_dir = Path.home()
-        home_dir = os.getenv("HOME")
-        self.file_path = "{}/.sharpshooter_config".format(home_dir)
-
+        self.file_path = os.path.expanduser('~') + '/.sharpshooter_config'
         if not os.path.isfile(self.file_path):
-            with open(self.file_path, 'w+') as new_file:
-                new_file.write(default_config)
-
+            with open(self.file_path, 'w') as f:
+                f.write(_DEFAULT_CONFIG)
         self.config = configparser.ConfigParser()
         self.config.read(self.file_path)
 
     def set_config_settings_value(self, key, value):
-        self.config.set('settings', key, value)
-        self.save_config()
-
-    def save_config(self):
-        with open(self.file_path, 'w') as configfile:
-            self.config.write(configfile)
+        self.config.set('settings', key, str(value))
+        with open(self.file_path, 'w') as f:
+            self.config.write(f)
 
     def get_key_for(self, command):
-        # in order to read strings with chars that need escaping we need to encode and then decode
-        return str(self.config['keys'][command]).encode('latin1').decode('unicode_escape')
+        return self.config['keys'][command].replace('\\n', '\n')
 
     def get_show_hidden(self):
         return self.config['settings'].getboolean('show_hidden')
+
+    def get_show_hotkeys(self):
+        return self.config['settings'].getboolean('show_hotkeys')

--- a/content.py
+++ b/content.py
@@ -36,6 +36,7 @@ class Content:
 
         self.config_manager = ConfigManager()
         self.show_hidden = self.config_manager.get_show_hidden()
+        self.show_hotkeys = self.config_manager.get_show_hotkeys()
 
         self.recalculate_content()
 
@@ -50,9 +51,12 @@ class Content:
         else:
             self.select_closest_to_hidden_item()
 
-        # save change to the config file
-        value_to_write = str(self.show_hidden)
-        self.config_manager.set_config_settings_value('show_hidden', value_to_write)
+        self.config_manager.set_config_settings_value('show_hidden', self.show_hidden)
+
+    def toggle_hotkeys(self):
+        logging.info("action: toggling hotkey guide from: {}".format(self.show_hotkeys))
+        self.show_hotkeys = not self.show_hotkeys
+        self.config_manager.set_config_settings_value('show_hotkeys', self.show_hotkeys)
 
     # the position of the selected line might change if items before it are hidden, but we want the same item
     # to be selected after either hiding or showing

--- a/controller.py
+++ b/controller.py
@@ -42,7 +42,8 @@ class Controller:
             self.input_keys.cut: self.content.cut,
             self.input_keys.zip_unzip: self.content.zip_unzip,
             self.input_keys.mark_item: self.content.toggle_mark_item,
-            self.input_keys.undo: self.content.undo
+            self.input_keys.undo: self.content.undo,
+            self.input_keys.toggle_hotkeys: self.content.toggle_hotkeys,
         }
 
     def run(self):
@@ -62,7 +63,8 @@ class Controller:
         self.pane_manager.render_path_indicator(self.content.cwd)
         self.pane_manager.render_panes(self.content.get_renderable_content())
         self.pane_manager.render_last_action_description(self.content.last_action_description)
-        self.pane_manager.render_hotkey_guide(self.input_keys.hotkey_guide)
+        if self.content.show_hotkeys:
+            self.pane_manager.render_hotkey_guide(self.input_keys.hotkey_guide)
 
         self.standard_screen.refresh()
         self.pane_manager.refresh_panes()

--- a/input_keys.py
+++ b/input_keys.py
@@ -28,6 +28,7 @@ class InputKeys:
         self.zip_unzip = config_manager.get_key_for('zip_unzip')
         self.mark_item = config_manager.get_key_for('mark_item')
         self.undo = config_manager.get_key_for('undo')
+        self.toggle_hotkeys = config_manager.get_key_for('toggle_hotkeys')
 
         self.hotkey_guide = self.generate_hotkey_guide()
 
@@ -44,6 +45,7 @@ class InputKeys:
             self.format_hotkey_description(self.mark_item, 'mark_item'),
             self.format_hotkey_description(self.undo, 'undo'),
             self.format_hotkey_description(self.open_terminal_key, 'terminal'),
+            self.format_hotkey_description(self.toggle_hotkeys, 'hotkeys'),
             self.format_hotkey_description(self.quit_key, 'quit')
         ]
         return "Keys: " + "; ".join(keys_to_display_in_guide)


### PR DESCRIPTION
## Summary

- **Fix encoding hack in `config_manager`**: replaces the opaque `encode('latin1').decode('unicode_escape')` one-liner with a plain `.replace('\\n', '\n')` — same effect, immediately readable
- **Simplify `config_manager`**: inline `save_config` into `set_config_settings_value`, use `os.path.expanduser` instead of `os.getenv("HOME")`, have `set_config_settings_value` call `str()` internally so callers don't have to
- **Add `toggle_hotkeys` key** (default `?`) and **`show_hotkeys` setting** (default `True`) to the default config
- **Toggleable hotkey guide bar**: press `?` at runtime to show/hide the bottom guide bar; state is persisted to config across sessions

## Test plan

- [ ] Launch the app — hotkey bar is visible by default
- [ ] Press `?` — bar disappears; press again — bar reappears
- [ ] Quit and relaunch — bar remembers its last state
- [ ] Edit `~/.sharpshooter_config`, change `show_hotkeys = False`, relaunch — bar starts hidden
- [ ] Change the `toggle_hotkeys` key in config, confirm the new key works
- [ ] All 33 unit tests pass (`python -m unittest discover -s tests`)

https://claude.ai/code/session_01Cevtzbebb2SZvajYFGby8p

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cevtzbebb2SZvajYFGby8p)_