### PR TITLE
Add delivery pipeline and website scaffold

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,16 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - run: python -m unittest discover -s tests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,25 @@
+name: Release
+
+on:
+  push:
+    tags: ['v*']
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Run tests
+        run: python -m unittest discover -s tests
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create ${{ github.ref_name }} \
+            --title "${{ github.ref_name }}" \
+            --generate-notes

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 
-# Sharpshooter ![LOGO](./img/sharpshooter_logo.svg) [![sharpshooter](https://snapcraft.io/sharpshooter/badge.svg)](https://snapcraft.io/sharpshooter) [![Build Status](https://travis-ci.com/vs-slavchev/sharpshooter.svg?branch=master)](https://travis-ci.com/vs-slavchev/sharpshooter)
+# Sharpshooter ![LOGO](./img/sharpshooter_logo.svg) [![CI](https://github.com/vs-slavchev/sharpshooter/actions/workflows/ci.yml/badge.svg)](https://github.com/vs-slavchev/sharpshooter/actions/workflows/ci.yml)
 
 Minimal file manager in the terminal.
 
@@ -25,24 +25,68 @@ Simple to configure and hack at.
 - [x] select multiple files
 - [x] configurable hotkeys
 
-# Install and remove
-`snap install --beta sharpshooter --devmode`
+# Install
 
-`snap remove sharpshooter`
+Requires Python 3 and [pipx](https://pipx.pypa.io) or [uv](https://docs.astral.sh/uv/).
 
-or download the latest .deb from the releases.
+**pipx**
+```bash
+pipx install git+https://github.com/vs-slavchev/sharpshooter.git
+```
 
-### Change hotkeys
+**uv**
+```bash
+uv tool install git+https://github.com/vs-slavchev/sharpshooter.git
+```
 
-- edit the `.sharpshooter_config` in your home dir with your preferred hotkeys
+**one-liner** (uses whichever of the above is available)
+```bash
+curl -fsSL https://vs-slavchev.github.io/sharpshooter/install.sh | bash
+```
+
+## Update
+
+```bash
+pipx upgrade sharpshooter   # or: uv tool upgrade sharpshooter
+```
+
+## Uninstall
+
+```bash
+pipx uninstall sharpshooter   # or: uv tool uninstall sharpshooter
+```
+
+## Configuration
+
+Edit `~/.sharpshooter_config` to change hotkeys or settings:
+
+```ini
+[keys]
+up = e
+down = n
+toggle_hotkeys = ?
+# ... all other keys
+
+[settings]
+show_hidden = False
+show_hotkeys = True
+```
+
+# Releasing a new version
+
+1. Merge all changes to `master` and ensure CI is green.
+2. Tag the commit:
+   ```bash
+   git tag v1.4.0
+   git push origin v1.4.0
+   ```
+3. The [Release workflow](.github/workflows/release.yml) runs the tests and creates a GitHub Release with auto-generated notes.
 
 # Technologies
 
 [![forthebadge made-with-python](http://ForTheBadge.com/images/badges/made-with-python.svg)](https://www.python.org/)
 
 [curses](https://docs.python.org/3/library/curses.html)
-
-[pathlib](https://docs.python.org/3/library/pathlib.html)
 
 [configparser](https://docs.python.org/3/library/configparser.html)
 
@@ -53,15 +97,6 @@ or download the latest .deb from the releases.
 # Block diagram
 ![block_diagram](./docs/block_diagram.svg)
 
-# Releasing as .deb
-1. install ```sudo apt-get install build-essential devscripts debhelper debmake dh-python python3-all```
-2. ```python3 setup.py sdist```
-3. ```mv dist/sharpshooter-*.tar.gz .```
-4. ```tar -xzmf sharpshooter-*.tar.gz```
-5. cd into sharpshooter-* folder
-6. ```debmake -b":python3"```
-7. ```debuild```
-
 # Running in IntelliJ
 - add `PYTHONUNBUFFERED=1` as env variable
 - check Emulate terminal in output console
@@ -69,4 +104,4 @@ or download the latest .deb from the releases.
 # Inspired by
 [ranger](https://ranger.github.io/)
 
-[Midnight Comander](https://midnight-commander.org/)
+[Midnight Commander](https://midnight-commander.org/)

--- a/website/index.html
+++ b/website/index.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>sharpshooter — minimal terminal file manager</title>
+</head>
+<body>
+  <h1>sharpshooter</h1>
+  <p>Minimal file manager in the terminal. Single-key hotkeys, zero friction.</p>
+
+  <h2>Install</h2>
+
+  <h3>With pipx</h3>
+  <pre>pipx install git+https://github.com/vs-slavchev/sharpshooter.git</pre>
+  <p>Update: <code>pipx upgrade sharpshooter</code></p>
+
+  <h3>With uv</h3>
+  <pre>uv tool install git+https://github.com/vs-slavchev/sharpshooter.git</pre>
+  <p>Update: <code>uv tool upgrade sharpshooter</code></p>
+
+  <h3>One-liner (requires pipx or uv)</h3>
+  <pre>curl -fsSL https://vs-slavchev.github.io/sharpshooter/install.sh | bash</pre>
+
+  <h2>Usage</h2>
+  <pre>sharpshooter</pre>
+
+  <h2>Default keys</h2>
+  <table>
+    <tr><td>e / n</td><td>up / down</td></tr>
+    <tr><td>k / i</td><td>parent / child directory</td></tr>
+    <tr><td>f</td><td>new folder</td></tr>
+    <tr><td>r</td><td>rename</td></tr>
+    <tr><td>c / d / p</td><td>copy / cut / paste</td></tr>
+    <tr><td>x</td><td>delete (to trash)</td></tr>
+    <tr><td>u</td><td>undo delete</td></tr>
+    <tr><td>z</td><td>zip / unzip</td></tr>
+    <tr><td>m</td><td>mark file</td></tr>
+    <tr><td>h</td><td>toggle hidden files</td></tr>
+    <tr><td>t</td><td>open terminal here</td></tr>
+    <tr><td>?</td><td>toggle hotkey guide</td></tr>
+    <tr><td>q</td><td>quit</td></tr>
+  </table>
+  <p>All keys are configurable in <code>~/.sharpshooter_config</code>.</p>
+
+  <h2>Links</h2>
+  <ul>
+    <li><a href="https://github.com/vs-slavchev/sharpshooter">GitHub</a></li>
+  </ul>
+</body>
+</html>

--- a/website/install.sh
+++ b/website/install.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO="https://github.com/vs-slavchev/sharpshooter.git"
+
+if command -v pipx &>/dev/null; then
+    pipx install "git+$REPO"
+elif command -v uv &>/dev/null; then
+    uv tool install "git+$REPO"
+else
+    echo "pipx or uv is required to install sharpshooter."
+    echo ""
+    echo "  Install pipx:  https://pipx.pypa.io/stable/installation/"
+    echo "  Install uv:    https://docs.astral.sh/uv/getting-started/installation/"
+    exit 1
+fi
+
+echo ""
+echo "sharpshooter installed. Run it with: sharpshooter"


### PR DESCRIPTION
## Summary

- **CI workflow**: tests run on every PR and on every push to master
- **Release workflow**: push a `v*` tag → tests run → GitHub Release created with auto-generated notes
- **Website scaffold** (`website/`): `index.html` with install instructions + `install.sh` one-liner; deployment wired up separately
- **README**: updated install section (pipx/uv), one-liner curl, update/uninstall commands, config snippet, release instructions for maintainers; Travis CI and Snap badges replaced with GitHub Actions badge

## How to release

```bash
git tag v1.4.0
git push origin v1.4.0
```

The release workflow handles the rest.

## Test plan

- [ ] Open a PR → CI badge goes green
- [ ] Merge to master → CI runs again on master
- [ ] Push a `v*` tag → Release workflow creates a GitHub Release with generated notes
- [ ] `pipx install git+https://github.com/vs-slavchev/sharpshooter.git` installs and runs correctly
- [ ] `curl … install.sh | bash` detects pipx/uv and installs

https://claude.ai/code/session_01Cevtzbebb2SZvajYFGby8p

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cevtzbebb2SZvajYFGby8p)_